### PR TITLE
Fix readme stream

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.software.codetime
 pluginName = Code Time
-pluginVersion = 2.7.5
+pluginVersion = 2.7.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/software/codetime/managers/ReadmeManager.java
+++ b/src/main/java/com/software/codetime/managers/ReadmeManager.java
@@ -29,7 +29,7 @@ public class ReadmeManager {
 
             ClassLoader classLoader = ReadmeManager.class.getClassLoader();
             String readmeFile = UserSessionManager.getReadmeFile();
-            try (InputStream inputStream = classLoader.getResourceAsStream("/assets/README.md")) {
+            try (InputStream inputStream = classLoader.getResourceAsStream("assets/README.md")) {
 
                 String fileContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
                 File f = new File(readmeFile);


### PR DESCRIPTION
fix streaming the readme the correct way

getting the following error
Do not request resource from classloader using path with leading slash

com.intellij.diagnostic.PluginException: /assets/README.md [Plugin: com.softwareco.intellij.plugin]