### PR TITLE
port to status bar widget factory

### DIFF
--- a/src/main/java/com/software/codetime/models/StatusBarFlowIconWidgetFactory.java
+++ b/src/main/java/com/software/codetime/models/StatusBarFlowIconWidgetFactory.java
@@ -1,0 +1,52 @@
+package com.software.codetime.models;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import com.software.codetime.managers.FlowManager;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+
+public class StatusBarFlowIconWidgetFactory implements StatusBarWidgetFactory {
+    private StatusBarKpmIconWidget widget;
+
+    @Override
+    public @NonNls
+    @NotNull String getId() {
+       return StatusBarKpmIconWidget.FLOW_ICON_ID;
+    }
+
+    @Override
+    public @Nls
+    @NotNull String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public @NotNull StatusBarKpmIconWidget createWidget(@NotNull Project project) {
+        this.widget = new StatusBarKpmIconWidget(StatusBarKpmIconWidget.FLOW_ICON_ID, "open-circle.png", () -> {
+            FlowManager.toggleFlowMode(false);
+        });
+        return this.widget;
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget widget) {
+        if (this.widget != null) {
+            this.widget.dispose();
+        }
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+        return false;
+    }
+}

--- a/src/main/java/com/software/codetime/models/StatusBarFlowTextWidgetFactory.java
+++ b/src/main/java/com/software/codetime/models/StatusBarFlowTextWidgetFactory.java
@@ -1,0 +1,52 @@
+package com.software.codetime.models;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import com.software.codetime.managers.FlowManager;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class StatusBarFlowTextWidgetFactory  implements StatusBarWidgetFactory {
+    private StatusBarKpmTextWidget widget;
+
+    @Override
+    public @NonNls
+    @NotNull
+    String getId() {
+        return StatusBarKpmTextWidget.FLOW_TEXT_ID;
+    }
+
+    @Override
+    public @Nls
+    @NotNull String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public @NotNull StatusBarKpmTextWidget createWidget(@NotNull Project project) {
+        this.widget = new StatusBarKpmTextWidget(StatusBarKpmTextWidget.FLOW_TEXT_ID, () -> {
+            FlowManager.toggleFlowMode(false);
+        });
+        return widget;
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget widget) {
+        if (this.widget != null) {
+            this.widget.dispose();
+        }
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+        return false;
+    }
+}

--- a/src/main/java/com/software/codetime/models/StatusBarIconWidgetFactory.java
+++ b/src/main/java/com/software/codetime/models/StatusBarIconWidgetFactory.java
@@ -1,0 +1,51 @@
+package com.software.codetime.models;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import com.software.codetime.toolwindows.codetime.SidebarToolWindow;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class StatusBarIconWidgetFactory implements StatusBarWidgetFactory {
+    private StatusBarKpmIconWidget widget;
+
+    @Override
+    public @NonNls
+    @NotNull String getId() {
+        return StatusBarKpmIconWidget.KPM_ICON_ID;
+    }
+
+    @Override
+    public @Nls
+    @NotNull String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public @NotNull StatusBarKpmIconWidget createWidget(@NotNull Project project) {
+        this.widget = new StatusBarKpmIconWidget(StatusBarKpmIconWidget.KPM_ICON_ID, "time-clock.png", () -> {
+            SidebarToolWindow.openToolWindow();
+        });
+        return this.widget;
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget widget) {
+        if (this.widget != null) {
+            this.widget.dispose();
+        }
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+        return false;
+    }
+}

--- a/src/main/java/com/software/codetime/models/StatusBarKpmIconWidget.java
+++ b/src/main/java/com/software/codetime/models/StatusBarKpmIconWidget.java
@@ -23,8 +23,10 @@ public class StatusBarKpmIconWidget implements StatusBarWidget {
     private final IconPresentation presentation = new IconPresentation();
     private final Consumer<MouseEvent> eventHandler;
 
-    public StatusBarKpmIconWidget(String id, final Runnable callback) {
+    public StatusBarKpmIconWidget(String id, String defaultIcon, final Runnable callback) {
         this.id = id;
+        // set the default icon
+        this.icon = UtilManager.getResourceIcon(defaultIcon, this.getClass().getClassLoader());
         eventHandler = new Consumer<MouseEvent>() {
             @Override
             public void consume(MouseEvent mouseEvent) {

--- a/src/main/java/com/software/codetime/models/StatusBarTextWidgetFactory.java
+++ b/src/main/java/com/software/codetime/models/StatusBarTextWidgetFactory.java
@@ -1,0 +1,52 @@
+package com.software.codetime.models;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import com.software.codetime.toolwindows.codetime.SidebarToolWindow;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class StatusBarTextWidgetFactory  implements StatusBarWidgetFactory {
+    private StatusBarKpmTextWidget widget;
+
+    @Override
+    public @NonNls
+    @NotNull
+    String getId() {
+        return StatusBarKpmTextWidget.KPM_TEXT_ID;
+    }
+
+    @Override
+    public @Nls
+    @NotNull String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public @NotNull StatusBarKpmTextWidget createWidget(@NotNull Project project) {
+        this.widget = new StatusBarKpmTextWidget(StatusBarKpmTextWidget.KPM_TEXT_ID, () -> {
+            SidebarToolWindow.openToolWindow();
+        });
+        return widget;
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget widget) {
+        if (this.widget != null) {
+            this.widget.dispose();
+        }
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+        return false;
+    }
+}

--- a/src/main/java/com/software/codetime/toolwindows/codetime/SidebarToolWindow.java
+++ b/src/main/java/com/software/codetime/toolwindows/codetime/SidebarToolWindow.java
@@ -37,7 +37,6 @@ public class SidebarToolWindow implements ToolWindowFactory {
         ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
         Content content = contentFactory.createContent(ctWindow.getContent(), "", false);
         toolWindow.getContentManager().addContent(content);
-        ctWindow.refresh();
         windowProject = project;
     }
 
@@ -46,7 +45,6 @@ public class SidebarToolWindow implements ToolWindowFactory {
         ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
         Content content = contentFactory.createContent(tv.getContent(), "", false);
         toolWindow.getContentManager().addContent(content);
-        tv.refresh();
         windowProject = project;
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,18 @@
         <toolWindow id="Code Time" order="first" anchor="left"
                     icon="/assets/paw-grey-rotated.png"
                     factoryClass="com.software.codetime.toolwindows.codetime.SidebarToolWindow"/>
+        <statusBarWidgetFactory id="buildCodeTimeIcon"
+                                implementation="com.software.codetime.models.StatusBarIconWidgetFactory"
+                                order="after writeActionWidget"/>
+        <statusBarWidgetFactory id="buildCodeTimeText"
+                                implementation="com.software.codetime.models.StatusBarTextWidgetFactory"
+                                order="after buildCodeTimeIcon"/>
+        <statusBarWidgetFactory id="buildFlowIcon"
+                                implementation="com.software.codetime.models.StatusBarFlowIconWidgetFactory"
+                                order="after buildCodeTimeText"/>
+        <statusBarWidgetFactory id="buildFlowText"
+                                implementation="com.software.codetime.models.StatusBarFlowTextWidgetFactory"
+                                order="after buildFlowIcon"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
* We need to port over to using the status bar widget factory to pass verifications. This is better anyway as it loads the status bar widgets from the plugin.xml

<img width="162" alt="Screen Shot 2022-04-13 at 1 07 02 PM" src="https://user-images.githubusercontent.com/35306917/163274865-31abc22f-2432-426f-8ddd-c77fed0e1777.png">
